### PR TITLE
Improve devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,24 +1,24 @@
-
 {
     "name": ".NET with Aspire",
-    "image": "mcr.microsoft.com/dotnet/sdk:8.0",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:8.0",
     "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+            "version": "latest"
+        },
         "ghcr.io/devcontainers/features/github-cli:1": {
             "version": "2"
-        },
-        "ghcr.io/devcontainers/features/powershell:1": {
-            "version": "latest"
         },
         "ghcr.io/azure/azure-dev/azd:0": {
             "version": "latest"
         },
-        "ghcr.io/devcontainers/features/common-utils:2": {}
+        "ghcr.io/devcontainers/features/dotnet:2": {
+            "version": "none",
+            "workloads": "aspire"
+        }
     },
     "customizations": {
         "vscode": {
             "extensions": [
-                "ms-dotnettools.vscode-dotnet-runtime",
                 "ms-dotnettools.csdevkit"
             ],
             "codespaces": {
@@ -28,5 +28,5 @@
             }
         }
     },
-    "postCreateCommand": "dotnet workload update && dotnet workload install aspire && dotnet restore"
+    "postCreateCommand": "find **/*.sln -exec dotnet restore {} \\;"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,9 +8,7 @@
         "ghcr.io/devcontainers/features/github-cli:1": {
             "version": "2"
         },
-        "ghcr.io/azure/azure-dev/azd:0": {
-            "version": "latest"
-        },
+        "ghcr.io/azure/azure-dev/azd:latest": {},
         "ghcr.io/devcontainers/features/dotnet:2": {
             "version": "none",
             "workloads": "aspire"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,5 +28,13 @@
             }
         }
     },
+    "mounts": [
+        {
+            "type": "volume",
+            "source": "x509stores",
+            "target": "/home/vscode/.dotnet/corefx/cryptography/x509stores"
+        }
+    ],
+    "onCreateCommand": "bash .devcontainer/setup-dotnet-dev-cert.sh",
     "postCreateCommand": "find **/*.sln -exec dotnet restore {} \\;"
 }

--- a/.devcontainer/setup-dotnet-dev-cert.sh
+++ b/.devcontainer/setup-dotnet-dev-cert.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Change ownership of the .dotnet directory to the vscode user (to avoid permission errors)
+sudo chown -R vscode:vscode /home/vscode/.dotnet
+
+# If there is no development certificate, this command will generate a new one
+dotnet dev-certs https
+
+# Export the ASP.NET Core HTTPS development certificate to a PEM file
+sudo -E dotnet dev-certs https --export-path /usr/local/share/ca-certificates/dotnet-dev-cert.crt --format pem
+
+# Add the PEM file to the trust store
+sudo update-ca-certificates


### PR DESCRIPTION
This PR contains some small improvements to the dev container definition:

The base image was changed from `dotnet/sdk` to `devcontainers/dotnet` since that one is intended for dev container usage and contains additional functionality like PowerShell 7. The `dotnet/sdk` image is more suitable for non-interactive use, like CI builds.

The `powershell` feature was removed since the base image already contains PowerShell 7.

The `docker-in-docker` version was explicitly set to `latest`, to remove potential doubts about which version is installed.

The `dotnet` feature was added to install the `aspire` workload during container builds.

The `dotnet workload install aspire` command was removed from `postCreateCommand` since Aspire is now part of the image.

The `dotnet restore` command was failing because there is no solution file in the root directory, so I changed it to restore solution files in subdirectories.

The `ms-dotnettools.vscode-dotnet-runtime` extension was removed since it's not needed, the dotnet SDK already contains the shared runtime which is used by the C# Dev Kit.

An `onCreateCommand` script was added to configure an HTTPS developer certificate for debugging. The certificate is persisted in a named volume, so it will survive container rebuilds.