### PR TITLE
Typo fix on servicedefaults.md

### DIFF
--- a/workshop/2-servicedefaults.md
+++ b/workshop/2-servicedefaults.md
@@ -58,7 +58,7 @@
 
 ## Run the application
 
-1. Run the application using a multip-project launch configuration in Visual Studio or Visual Studio Code.
+1. Run the application using a multiple-project launch configuration in Visual Studio or Visual Studio Code.
 
 	- Visual Studio: Right click on the `MyWeatherHub` solution and go to properties. Select the `Api` and `MyWeatherHub` as startup projects, select `OK`. 
 		- ![Visual Studio solution properties](./media/vs-multiproject.png)


### PR DESCRIPTION
This pull request includes a minor textual correction in the `workshop/2-servicedefaults.md` file. The change corrects the spelling of "multip-project" to "multiple-project" in the instructions for running the application.