### PR TITLE
Fix header typo in 3-dashboard-apphost.md

### DIFF
--- a/workshop/3-dashboard-apphost.md
+++ b/workshop/3-dashboard-apphost.md
@@ -36,7 +36,7 @@ Before continuing, consider some common terminology used in .NET Aspire:
 	dotnet new aspire-apphost -n AppHost
 	```
 
-## Configure Service Defaults
+## Add Project References
 
 1. Add a reference to the `Api` and `MyWeatherHub` projects in the new `AppHost` project:
 
@@ -45,7 +45,6 @@ Before continuing, consider some common terminology used in .NET Aspire:
 
 	> Pro Tip: In Visual Studio 2022, you can drag and drop the project onto another project to add a reference.
 1. When these references are add Source Generators automatically generate the necessary code to reference the projects in the App Host.
-
 
 ## Orchestrate the Application
 
@@ -91,6 +90,7 @@ Before continuing, consider some common terminology used in .NET Aspire:
 	![.NET Aspire Dashboard](./media/dashboard-metrics.png)
 
 ## Create an error
+
 1. Open the `Structured` tab on the dashboard.
 1. Set the `Level` to `Error` and notice that no errors appear
 1. On the `MyWeatherApp` website click on several different cities to generate errors. Usually 5 different cities will generate an error.


### PR DESCRIPTION
This pull request includes changes in the `workshop/3-dashboard-apphost.md` file, primarily focusing on modifying section headers and adding additional instructions. The main changes are the renaming of the "Configure Service Defaults" section to "Add Project References", the removal of a blank line, and the addition of instructions on how to create an error.

Key changes:

* [`workshop/3-dashboard-apphost.md`](diffhunk://#diff-4012c5a7c65dba898ba85d4e4eda83f6a88b51a270b824ea197510acabab8192L39-R39): The section "Configure Service Defaults" has been renamed to "Add Project References", indicating a shift in focus towards managing project dependencies.
* [`workshop/3-dashboard-apphost.md`](diffhunk://#diff-4012c5a7c65dba898ba85d4e4eda83f6a88b51a270b824ea197510acabab8192L49): A blank line has been removed, which could be for improving readability or conforming to a specific document format.
* [`workshop/3-dashboard-apphost.md`](diffhunk://#diff-4012c5a7c65dba898ba85d4e4eda83f6a88b51a270b824ea197510acabab8192R93): Instructions have been added to the "Create an error" section, providing users with a step-by-step guide to generate errors for testing purposes.