### PR TITLE
Fix to 2-servicedefaults.md

### DIFF
--- a/workshop/2-servicedefaults.md
+++ b/workshop/2-servicedefaults.md
@@ -40,8 +40,8 @@
 
 	- Right-click on the `Api` project and select `Add` > `Reference`.
 		- Check the `ServiceDefaults` project and click `OK`.
-	- Right-click on the `Api` project and select `Add` > `Reference`.
-		- Check the `MyWeatherHub` project and click `OK`.
+	- Right-click on the `MyWeatherHub` project and select `Add` > `Reference`.
+		- Check the `ServiceDefaults` project and click `OK`.
 
 	> Pro Tip: In Visual Studio 2022, you can drag and drop the project onto another project to add a reference.
 


### PR DESCRIPTION
This pull request includes a small but important change to the `workshop/2-servicedefaults.md` file. The change corrects the instructions for adding project references.

* [`workshop/2-servicedefaults.md`](diffhunk://#diff-a87cd8f4abfa125227312b42a585c62f56066be45cdee2a8be9e7433f64af404L43-R44): Corrected the instructions to add a reference from the `MyWeatherHub` project to the `ServiceDefaults` project instead of the `Api` project.