### PR TITLE
Markdown fix in 3-dashboard-apphost.md

### DIFF
--- a/workshop/3-dashboard-apphost.md
+++ b/workshop/3-dashboard-apphost.md
@@ -82,7 +82,7 @@ Before continuing, consider some common terminology used in .NET Aspire:
 1. Back on the Aspire Dashboard, click on the `View Logs` button to see the console logs from the `Api` and `MyWeatherHub` projects.
 1. Select the `Traces` tab and select `View` on a trace where the API is being called.
 
-    ![.NET Aspire Dashboard](./media/dashboard-trace.png)]
+    ![.NET Aspire Dashboard](./media/dashboard-trace.png)
 
 1. Explore the `Metrics` tab to see the metrics for the `Api` and `MyWeatherHub` projects.
 


### PR DESCRIPTION
This pull request includes a small correction to the `workshop/3-dashboard-apphost.md` file. The change fixes a typo in the image reference for the .NET Aspire Dashboard. 

* [`workshop/3-dashboard-apphost.md`](diffhunk://#diff-4012c5a7c65dba898ba85d4e4eda83f6a88b51a270b824ea197510acabab8192L85-R85): Corrected the image reference by removing an extra closing bracket.